### PR TITLE
Pin zmk from 2023-03-25

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -7,7 +7,7 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      revision: ae8299edb3d638f1332475b1da0fdf40afa43fe4
       import: app/west.yml
   self:
     path: config


### PR DESCRIPTION
After some upstream changes in ZMK, zmk-ardux builds are failing ([example](https://github.com/Lykos153/zmk-ardux/actions/runs/4947891536/jobs/8847882010)). This PR pins the last revision of ZMK before the breaking changes.