### PR TITLE
add missing config line for 6 bluetooth profiles

### DIFF
--- a/config/boards/shields/artboard/artboard_left.conf
+++ b/config/boards/shields/artboard/artboard_left.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=y

--- a/config/boards/shields/artboard/artboard_right.conf
+++ b/config/boards/shields/artboard/artboard_right.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=y

--- a/config/boards/shields/bluehand/bluehand_left.conf
+++ b/config/boards/shields/bluehand/bluehand_left.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=n

--- a/config/boards/shields/bluehand/bluehand_right.conf
+++ b/config/boards/shields/bluehand/bluehand_right.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=n

--- a/config/boards/shields/corne_left/corne_5_col_ardux_left.conf
+++ b/config/boards/shields/corne_left/corne_5_col_ardux_left.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=y

--- a/config/boards/shields/corne_left/corne_5_col_ardux_left_big.conf
+++ b/config/boards/shields/corne_left/corne_5_col_ardux_left_big.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=y

--- a/config/boards/shields/corne_left/corne_ardux_left.conf
+++ b/config/boards/shields/corne_left/corne_ardux_left.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=y

--- a/config/boards/shields/corne_right/corne_5_col_ardux_right.conf
+++ b/config/boards/shields/corne_right/corne_5_col_ardux_right.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=y

--- a/config/boards/shields/corne_right/corne_5_col_ardux_right_big.conf
+++ b/config/boards/shields/corne_right/corne_5_col_ardux_right_big.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=y

--- a/config/boards/shields/corne_right/corne_ardux_right.conf
+++ b/config/boards/shields/corne_right/corne_ardux_right.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=y

--- a/config/boards/shields/cradio_left/cradio_ardux_left.conf
+++ b/config/boards/shields/cradio_left/cradio_ardux_left.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=n

--- a/config/boards/shields/cradio_left/cradio_ardux_thumb_left.conf
+++ b/config/boards/shields/cradio_left/cradio_ardux_thumb_left.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=n

--- a/config/boards/shields/cradio_right/cradio_ardux_right.conf
+++ b/config/boards/shields/cradio_right/cradio_ardux_right.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=n

--- a/config/boards/shields/cradio_right/cradio_ardux_thumb_right.conf
+++ b/config/boards/shields/cradio_right/cradio_ardux_thumb_right.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=n

--- a/config/boards/shields/the_paintbrush/the_paintbrush_left.conf
+++ b/config/boards/shields/the_paintbrush/the_paintbrush_left.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=y

--- a/config/boards/shields/the_paintbrush/the_paintbrush_right.conf
+++ b/config/boards/shields/the_paintbrush/the_paintbrush_right.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=y

--- a/config/boards/shields/tidbit_ardux_left/tidbit_ardux_left.conf
+++ b/config/boards/shields/tidbit_ardux_left/tidbit_ardux_left.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=y

--- a/config/boards/shields/tidbit_ardux_right/tidbit_ardux_right.conf
+++ b/config/boards/shields/tidbit_ardux_right/tidbit_ardux_right.conf
@@ -8,6 +8,7 @@ CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS=8
 
 # Tune bluetooth profiles for quick select
 CONFIG_BT_MAX_CONN=6
+CONFIG_BT_MAX_PAIRED=6
 
 # Enable display (layer in use is helpful)
 CONFIG_ZMK_DISPLAY=y


### PR DESCRIPTION
As per https://zmk.dev/docs/behaviors/bluetooth , adjusting the number of available bluetooth profiles (from 5) requires both `CONFIG_BT_MAX_CONN` and `CONFIG_BT_MAX_PAIRED` to be set. Since one is missing, at the moment there are only 5 profiles available.
I tested on my right-handed paintbrush and applied the fix in the same way for all other shields.