### PR TITLE
Enable Mouse Functionality and layer

### DIFF
--- a/config/ardux.dtsi
+++ b/config/ardux.dtsi
@@ -7,6 +7,7 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/pointing.h>
 
 /*****************************************
  * Macros for filling in "&none" in the right places in the keymap for re-use needs
@@ -209,9 +210,10 @@
 #define LAYER_ID_PARENTHETICALS 3
 #define LAYER_ID_NAVIGATION 4
 #define LAYER_ID_BT_SEL 5
-#define LAYER_ID_CUSTOM 6
-#define LAYER_ID_BIG_SYM 7
-#define LAYER_ID_BIG_FUNCTION 8
+#define LAYER_ID_MOUSE 6
+#define LAYER_ID_CUSTOM 7
+#define LAYER_ID_BIG_SYM 8
+#define LAYER_ID_BIG_FUNCTION 9
 
 /*****************************************
  * Standard ARDUX combo definitions
@@ -246,7 +248,7 @@
 		combo_j           { layers = <LAYER_ID_BASE>; timeout-ms = <TIMEOUT_COMBO_2>; key-positions = <KEY_T KEY_S>; bindings = <&kp J>; };
 		combo_w           { layers = <LAYER_ID_BASE>; timeout-ms = <TIMEOUT_COMBO_2>; key-positions = <KEY_A KEY_S>; bindings = <&kp W>; };
 		combo_k           { layers = <LAYER_ID_BASE>; timeout-ms = <TIMEOUT_COMBO_2>; key-positions = <KEY_Y KEY_O>; bindings = <&kp K>; };
-		combo_period       { layers = <LAYER_ID_BASE>; timeout-ms = <TIMEOUT_COMBO_2>; key-positions = <KEY_A KEY_Y>; bindings = <&kp PERIOD>; };
+		combo_period      { layers = <LAYER_ID_BASE>; timeout-ms = <TIMEOUT_COMBO_2>; key-positions = <KEY_A KEY_Y>; bindings = <&kp PERIOD>; };
 		combo_comma       { layers = <LAYER_ID_BASE>; timeout-ms = <TIMEOUT_COMBO_2>; key-positions = <KEY_A KEY_I>; bindings = <&kp COMMA>; };
 		combo_slash       { layers = <LAYER_ID_BASE>; timeout-ms = <TIMEOUT_COMBO_2>; key-positions = <KEY_A KEY_O>; bindings = <&kp SLASH>; };
 		combo_exclamation { layers = <LAYER_ID_BASE>; timeout-ms = <TIMEOUT_COMBO_2>; key-positions = <KEY_T KEY_I>; bindings = <&kp EXCL>; };
@@ -261,6 +263,7 @@
 		 *****************************************/
 		combo_esc              { timeout-ms = <TIMEOUT_COMBO_3>; key-positions = <KEY_A KEY_R KEY_O>; bindings = <&kp ESC>; };
 		combo_layer_navigation { timeout-ms = <TIMEOUT_COMBO_3>; key-positions = <KEY_R KEY_E KEY_I>; bindings = <&tog LAYER_ID_NAVIGATION>; };
+		combo_layer_mouse      { timeout-ms = <TIMEOUT_COMBO_3>; key-positions = <KEY_A KEY_T KEY_Y>; bindings = <&tog LAYER_ID_MOUSE>; };
 
 		combo_m            { layers = <LAYER_ID_BASE>; timeout-ms = <TIMEOUT_COMBO_3>; key-positions = <KEY_Y KEY_I KEY_O>; bindings = <&kp M>; };
 		combo_d            { layers = <LAYER_ID_BASE>; timeout-ms = <TIMEOUT_COMBO_3>; key-positions = <KEY_A KEY_R KEY_T>; bindings = <&kp D>; };
@@ -399,6 +402,16 @@
 				TRAILING_NONES
 			>;
 		};
+		mouse {
+			display-name = "Mouse";
+			bindings = <
+				LEADING_NONES
+				&mkp LCLK                                        &mmv MOVE_UP    &mkp RCLK        &msc SCRL_UP
+				MIDDLE_NONES
+				&mmv MOVE_LEFT                                   &mmv MOVE_DOWN  &mmv MOVE_RIGHT  &msc SCRL_DOWN
+				TRAILING_NONES
+			>;
+		};
 		ARDUX_LAYER_CUSTOM
 		#if defined ARDUX_BIG
 		big_ardux_symbol {
@@ -519,6 +532,16 @@
 				ARDUX_BT_TOP    &bt BT_SEL 2 &bt BT_SEL 1 &bt BT_SEL 0
 				MIDDLE_NONES
 				ARDUX_BT_BOTTOM &bt BT_SEL 5 &bt BT_SEL 4 &bt BT_SEL 3
+				TRAILING_NONES
+			>;
+		};
+		mouse {
+			display-name = "Mouse";
+			bindings = <
+				LEADING_NONES
+				&msc SCRL_UP                                   &mkp RCLK  &mmv MOVE_UP    &mkp LCLK
+				MIDDLE_NONES
+				&msc SCRL_DOWN                                   &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_RIGHT
 				TRAILING_NONES
 			>;
 		};

--- a/config/boards/shields/artboard/artboard_left.conf
+++ b/config/boards/shields/artboard/artboard_left.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=y
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/artboard/artboard_right.conf
+++ b/config/boards/shields/artboard/artboard_right.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=y
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/bluehand/bluehand_left.conf
+++ b/config/boards/shields/bluehand/bluehand_left.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=n
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/bluehand/bluehand_right.conf
+++ b/config/boards/shields/bluehand/bluehand_right.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=n
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/corne_left/corne_5_col_ardux_left.conf
+++ b/config/boards/shields/corne_left/corne_5_col_ardux_left.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=y
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/corne_left/corne_5_col_ardux_left_big.conf
+++ b/config/boards/shields/corne_left/corne_5_col_ardux_left_big.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=y
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/corne_left/corne_ardux_left.conf
+++ b/config/boards/shields/corne_left/corne_ardux_left.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=y
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/corne_right/corne_5_col_ardux_right.conf
+++ b/config/boards/shields/corne_right/corne_5_col_ardux_right.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=y
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/corne_right/corne_5_col_ardux_right_big.conf
+++ b/config/boards/shields/corne_right/corne_5_col_ardux_right_big.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=y
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/corne_right/corne_ardux_right.conf
+++ b/config/boards/shields/corne_right/corne_ardux_right.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=y
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/cradio_left/cradio_ardux_left.conf
+++ b/config/boards/shields/cradio_left/cradio_ardux_left.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=n
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/cradio_left/cradio_ardux_thumb_left.conf
+++ b/config/boards/shields/cradio_left/cradio_ardux_thumb_left.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=n
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/cradio_right/cradio_ardux_right.conf
+++ b/config/boards/shields/cradio_right/cradio_ardux_right.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=n
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/cradio_right/cradio_ardux_thumb_right.conf
+++ b/config/boards/shields/cradio_right/cradio_ardux_thumb_right.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=n
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/the_paintbrush/the_paintbrush_left.conf
+++ b/config/boards/shields/the_paintbrush/the_paintbrush_left.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=y
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/the_paintbrush/the_paintbrush_right.conf
+++ b/config/boards/shields/the_paintbrush/the_paintbrush_right.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=y
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/tidbit_ardux_left/tidbit_ardux_left.conf
+++ b/config/boards/shields/tidbit_ardux_left/tidbit_ardux_left.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=y
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/boards/shields/tidbit_ardux_right/tidbit_ardux_right.conf
+++ b/config/boards/shields/tidbit_ardux_right/tidbit_ardux_right.conf
@@ -15,3 +15,6 @@ CONFIG_ZMK_DISPLAY=y
 
 # Turn off sleep
 CONFIG_ZMK_SLEEP=n
+
+# Enables mouse functionality
+CONFIG_ZMK_POINTING=y

--- a/config/west.yml
+++ b/config/west.yml
@@ -7,7 +7,7 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: 8c6bda260ace119b3c22a21bdcdd6d17a83fc5eb
+      revision: main
       import: app/west.yml
   self:
     path: config

--- a/config/west.yml
+++ b/config/west.yml
@@ -7,7 +7,7 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      revision: 6f85f48b19afae04f98e9abacb36ce1425b61f78
       import: app/west.yml
   self:
     path: config


### PR DESCRIPTION
With the mouse support now available in zmk (https://zmk.dev/docs/keymaps/behaviors/mouse-emulation), enables the 'Lock Mouse' layer which is shown on the ardux.io and artsey.io layouts, which were previously unavailable in ZMK.